### PR TITLE
fix: update store link to active endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ We will reply to you within one working day.
 
 Please visit the following page to purchase our products:
 
-http://store.freenove.com
+http://freenove.com/store.html
 
 Business customers please contact us through the following email address:
 


### PR DESCRIPTION
fixes #6

the old store.freenove.com link wasn't working anymore — updated it to the current store URL at freenove.com/store.html as mentioned in the issue.